### PR TITLE
Switch memory resource units to MB (mem_mb) and update SLURM/Java usage

### DIFF
--- a/config/slurm/config.yaml
+++ b/config/slurm/config.yaml
@@ -3,7 +3,7 @@ cluster:
   sbatch
     --nodes={resources.nodes}
     --cpus-per-task={resources.cpus}
-    --mem={resources.mem_gb}G
+    --mem={resources.mem_mb}
     --time={resources.time}
     --job-name=smk-{rule}-{wildcards}
     --output=logs_slurm/{rule}/{rule}-{wildcards}-%j
@@ -13,7 +13,7 @@ default-resources:
     - time=720
     - nodes=1
     - ntasks=1
-    - mem_gb=4
+    - mem_mb=4000
     - cpus=1
     - partition=basic,gpu,himem,himemgpu
 restart-times: 5

--- a/workflow/rules/2_preprocess.smk
+++ b/workflow/rules/2_preprocess.smk
@@ -64,7 +64,7 @@ rule annotate_biallelic_snps:
         txt="results/annotated_data/{species}/{dataset}/all/{i}.biallelic.snps.{ref_genome}_multianno.txt",
     resources:
         cpus=8,
-        mem_gb=32,
+        mem_mb=32000,
     params:
         output_prefix="results/annotated_data/{species}/{dataset}/all/{i}.biallelic.snps",
         db_dir="resources/tools/annovar/{ref_genome}_db",
@@ -144,7 +144,7 @@ rule extract_1pop_exonic_data:
             else "$9~/^nonsynonymous/"
         ),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/preprocess/extract_1pop_exonic_data.{species}.{dataset}.{ppl}.{i}.{mut_type}.{ref_genome}.log",
     conda:
@@ -198,7 +198,7 @@ rule extract_2pop_exonic_data:
             else "$9~/^nonsynonymous/"
         ),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/preprocess/extract_2pop_exonic_data.{species}.{dataset}.{pair}.{i}.{mut_type}.{ref_genome}.log",
     conda:

--- a/workflow/rules/3_polarization.smk
+++ b/workflow/rules/3_polarization.smk
@@ -26,7 +26,7 @@ rule polarize_1pop:
         vcf=temp("results/polarized_data/{species}/{dataset}/1pop/{ppl}/{ppl}.{i}.biallelic.snps.vcf.gz"),
         idx=temp("results/polarized_data/{species}/{dataset}/1pop/{ppl}/{ppl}.{i}.biallelic.snps.vcf.gz.tbi"),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/polarization/polarize_1pop.{species}.{dataset}.{ppl}.{i}.log",
     conda:
@@ -43,7 +43,7 @@ rule polarize_2pop:
         vcf=temp("results/polarized_data/{species}/{dataset}/2pop/{pair}/{pair}.{i}.biallelic.snps.vcf.gz"),
         idx=temp("results/polarized_data/{species}/{dataset}/2pop/{pair}/{pair}.{i}.biallelic.snps.vcf.gz.tbi"),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/polarization/polarize_2pop.{species}.{dataset}.{pair}.{i}.log",
     conda:
@@ -60,7 +60,7 @@ rule polarize_1pop_exonic_data:
         vcf=temp("results/polarized_data/{species}/{dataset}/1pop/{ppl}/{ppl}.{i}.biallelic.{mut_type}.snps.{ref_genome}.vcf.gz"),
         idx=temp("results/polarized_data/{species}/{dataset}/1pop/{ppl}/{ppl}.{i}.biallelic.{mut_type}.snps.{ref_genome}.vcf.gz.tbi"),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/polarization/polarize_1pop_exonic_data.{species}.{dataset}.{ppl}.{i}.{mut_type}.{ref_genome}.log",
     conda:
@@ -77,7 +77,7 @@ rule polarize_2pop_exonic_data:
         vcf=temp("results/polarized_data/{species}/{dataset}/2pop/{pair}/{pair}.{i}.biallelic.{mut_type}.snps.{ref_genome}.vcf.gz"),
         idx=temp("results/polarized_data/{species}/{dataset}/2pop/{pair}/{pair}.{i}.biallelic.{mut_type}.snps.{ref_genome}.vcf.gz.tbi"),
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/polarization/polarize_2pop_exonic_data.{species}.{dataset}.{pair}.{i}.{mut_type}.{ref_genome}.log",
     conda:

--- a/workflow/rules/4.1_positive_selection_selscan.smk
+++ b/workflow/rules/4.1_positive_selection_selscan.smk
@@ -131,7 +131,7 @@ rule plot_selscan:
         color1=selscan_config["manhattan_plot_color1"],
         color2=selscan_config["manhattan_plot_color2"],
     resources:
-        mem_gb=16,
+        mem_mb=16000,
     log:
         "logs/positive_selection/plot_selscan.{species}.{dataset}.{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:
@@ -152,7 +152,7 @@ rule annotate_selscan_outliers:
     output:
         annotated_outliers="results/positive_selection/selscan/{species}/{dataset}/1pop/{ppl}/{method}_{maf}/{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/positive_selection/annotate_selscan_outliers.{species}.{dataset}.{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:
@@ -213,7 +213,7 @@ rule enrichment_selscan_gowinda:
         total_snps="results/positive_selection/selscan/{species}/{dataset}/1pop/{ppl}/{method}_{maf}/{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.total.snps.tsv",
         enrichment="results/positive_selection/selscan/{species}/{dataset}/1pop/{ppl}/{method}_{maf}/{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/positive_selection/enrichment_selscan_gowinda.{species}.{dataset}.{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
@@ -227,7 +227,7 @@ rule enrichment_selscan_gowinda:
             bcftools query -f "%CHROM\\t%POS\\n" $i
         done > {output.total_snps} 2>> {log}
 
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -278,7 +278,7 @@ rule plot_gowinda_enrichment_selscan:
     params:
         title=add_selscan_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/positive_selection/plot_gowinda_enrichment_selscan.{species}.{dataset}.{ppl}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:

--- a/workflow/rules/4.2_positive_selection_selscan_xp.smk
+++ b/workflow/rules/4.2_positive_selection_selscan_xp.smk
@@ -153,7 +153,7 @@ rule plot_selscan_xp:
         color1=selscan_config["manhattan_plot_color1"],
         color2=selscan_config["manhattan_plot_color2"],
     resources:
-        mem_gb=16,
+        mem_mb=16000,
     log:
         "logs/positive_selection/plot_selscan_xp.{species}.{dataset}.{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:
@@ -174,7 +174,7 @@ rule annotate_selscan_xp_outliers:
     output:
         annotated_outliers="results/positive_selection/selscan/{species}/{dataset}/2pop/{pair}/{method}_{maf}/{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/positive_selection/annotate_selscan_xp_outliers.{species}.{dataset}.{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:
@@ -235,7 +235,7 @@ rule enrichment_selscan_xp_gowinda:
         total_snps="results/positive_selection/selscan/{species}/{dataset}/2pop/{pair}/{method}_{maf}/{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.total.snps.tsv",
         enrichment="results/positive_selection/selscan/{species}/{dataset}/2pop/{pair}/{method}_{maf}/{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/positive_selection/enrichment_selscan_xp_gowinda.{species}.{dataset}.{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
@@ -247,7 +247,7 @@ rule enrichment_selscan_xp_gowinda:
         for i in {input.total}; do
             bcftools query -f "%CHROM\\t%POS\\n" $i
         done > {output.total_snps} 2>> {log}
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -297,7 +297,7 @@ rule plot_gowinda_enrichment_selscan_xp:
     params:
         title=add_selscan_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/positive_selection/plot_gowinda_enrichment_selscan_xp.{species}.{dataset}.{pair}.normalized.{method}.maf_{maf}.top_{cutoff}.log",
     conda:

--- a/workflow/rules/4.3_positive_selection_scikit-allel.smk
+++ b/workflow/rules/4.3_positive_selection_scikit-allel.smk
@@ -150,7 +150,7 @@ rule annotate_tajima_d_outliers:
     output:
         annotated_outliers="results/positive_selection/scikit-allel/{species}/{dataset}/1pop/{ppl}/{method}/{window}_{step}/{ppl}.{method}.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/positive_selection/annotate_tajima_d_outliers.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:
@@ -211,7 +211,7 @@ rule enrichment_tajima_d_gowinda:
         total_snps="results/positive_selection/scikit-allel/{species}/{dataset}/1pop/{ppl}/{method}/{window}_{step}/{ppl}.{method}.top_{cutoff}.total.snps.tsv",
         enrichment="results/positive_selection/scikit-allel/{species}/{dataset}/1pop/{ppl}/{method}/{window}_{step}/{ppl}.{method}.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/positive_selection/enrichment_tajima_d_gowinda.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
@@ -225,7 +225,7 @@ rule enrichment_tajima_d_gowinda:
             bcftools query -f "%CHROM\t%POS\n" $i
         done > {output.total_snps} 2>> {log}
 
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -276,7 +276,7 @@ rule plot_gowinda_enrichment_tajima_d:
     params:
         title=add_scikit_allel_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/positive_selection/plot_gowinda_enrichment_tajima_d.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:

--- a/workflow/rules/4.4_positive_selection_scikit-allel_xp.smk
+++ b/workflow/rules/4.4_positive_selection_scikit-allel_xp.smk
@@ -149,7 +149,7 @@ rule annotate_delta_tajima_d_outliers:
     output:
         annotated_outliers="results/positive_selection/scikit-allel/{species}/{dataset}/2pop/{pair}/{method}/{window}_{step}/{pair}.{method}.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/positive_selection/annotate_delta_tajima_d_outliers.{species}.{dataset}.{pair}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:
@@ -212,7 +212,7 @@ rule enrichment_delta_tajima_d_gowinda:
         total_snps="results/positive_selection/scikit-allel/{species}/{dataset}/2pop/{pair}/{method}/{window}_{step}/{pair}.{method}.top_{cutoff}.total.snps.tsv",
         enrichment="results/positive_selection/scikit-allel/{species}/{dataset}/2pop/{pair}/{method}/{window}_{step}/{pair}.{method}.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/positive_selection/enrichment_delta_tajima_d_gowinda.{species}.{dataset}.{pair}.{method}.{window}_{step}.top_{cutoff}.log",
@@ -226,7 +226,7 @@ rule enrichment_delta_tajima_d_gowinda:
             bcftools query -f "%CHROM\t%POS\n" $i
         done > {output.total_snps} 2>> {log}
 
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -278,7 +278,7 @@ rule plot_gowinda_enrichment_delta_tajima_d:
     params:
         title=add_scikit_allel_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/positive_selection/plot_gowinda_enrichment_delta_tajima_d.{species}.{dataset}.{pair}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:

--- a/workflow/rules/5.1_balancing_selection_betascan.smk
+++ b/workflow/rules/5.1_balancing_selection_betascan.smk
@@ -102,7 +102,7 @@ rule plot_betascan:
         color1=betascan_config["manhattan_plot_color1"],
         color2=betascan_config["manhattan_plot_color2"],
     resources:
-        mem_gb=16,
+        mem_mb=16000,
     log:
         "logs/balancing_selection/plot_betascan.{species}.{dataset}.{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.log",
     conda:
@@ -123,7 +123,7 @@ rule annotate_betascan_outliers:
     output:
         annotated_outliers="results/balancing_selection/betascan/{species}/{dataset}/{ppl}/m_{core_frq}/{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/balancing_selection/annotate_betascan_outliers.{species}.{dataset}.{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.log",
     conda:
@@ -184,7 +184,7 @@ rule enrichment_betascan_gowinda:
         total_snps="results/balancing_selection/betascan/{species}/{dataset}/{ppl}/m_{core_frq}/{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.total.snps.tsv",
         enrichment="results/balancing_selection/betascan/{species}/{dataset}/{ppl}/m_{core_frq}/{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/balancing_selection/enrichment_betascan_gowinda.{species}.{dataset}.{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.log",
@@ -198,7 +198,7 @@ rule enrichment_betascan_gowinda:
             bcftools query -f "%CHROM\\t%POS\\n" $i
         done > {output.total_snps} 2>> {log}
 
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -250,7 +250,7 @@ rule plot_gowinda_enrichment_betascan:
     params:
         title=add_betascan_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/balancing_selection/plot_gowinda_enrichment_betascan.{species}.{dataset}.{ppl}.{ref_genome}.m_{core_frq}.b1.top_{cutoff}.log",
     conda:

--- a/workflow/rules/5.2_balancing_selection_scikit-allel.smk
+++ b/workflow/rules/5.2_balancing_selection_scikit-allel.smk
@@ -148,7 +148,7 @@ rule annotate_tajima_d_balancing_outliers:
     output:
         annotated_outliers="results/balancing_selection/scikit-allel/{species}/{dataset}/{method}/{ppl}/{window}_{step}/{ppl}.{method}.top_{cutoff}.annotated.outliers",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
     log:
         "logs/balancing_selection/annotate_tajima_d_balancing_outliers.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:
@@ -209,7 +209,7 @@ rule enrichment_tajima_d_balancing_gowinda:
         total_snps="results/balancing_selection/scikit-allel/{species}/{dataset}/{method}/{ppl}/{window}_{step}/{ppl}.{method}.top_{cutoff}.total.snps.tsv",
         enrichment="results/balancing_selection/scikit-allel/{species}/{dataset}/{method}/{ppl}/{window}_{step}/{ppl}.{method}.top_{cutoff}.gowinda.enrichment.tsv",
     resources:
-        mem_gb=32,
+        mem_mb=32000,
         cpus=8,
     log:
         "logs/balancing_selection/enrichment_tajima_d_balancing_gowinda.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
@@ -223,7 +223,7 @@ rule enrichment_tajima_d_balancing_gowinda:
             bcftools query -f "%CHROM\t%POS\n" $i
         done > {output.total_snps} 2>> {log}
 
-        java -Xmx{resources.mem_gb}g -jar {input.gowinda} \
+        java -Xmx{resources.mem_mb}m -jar {input.gowinda} \
             --snp-file {output.total_snps} \
             --candidate-snp-file {output.outlier_snps} \
             --gene-set-file {input.go2gene} \
@@ -275,7 +275,7 @@ rule plot_gowinda_enrichment_tajima_d_balancing:
     params:
         title=add_scikit_allel_title,
     resources:
-        mem_gb=8,
+        mem_mb=8000,
     log:
         "logs/balancing_selection/plot_gowinda_enrichment_tajima_d_balancing.{species}.{dataset}.{ppl}.{method}.{window}_{step}.top_{cutoff}.log",
     conda:


### PR DESCRIPTION
### Motivation
- Standardize memory resource handling to megabyte granularity so SLURM and Java flags receive explicit MB values and avoid ambiguous GB suffixes.

### Description
- Replaced `mem_gb` resource fields with `mem_mb` across the Snakemake rules and updated numeric values accordingly (e.g. `32` -> `32000`).
- Updated `config/slurm/config.yaml` to pass `--mem={resources.mem_mb}` to `sbatch` and changed the default resource key to `mem_mb`.
- Updated Java invocations to use `-Xmx{resources.mem_mb}m` instead of `-Xmx{resources.mem_gb}g` so Java heap sizes match the new MB resource field.
- Changes touch the SLURM config and multiple workflow rule files under `workflow/rules/` including `2_preprocess.smk`, `3_polarization.smk`, `4.1_*`, `4.2_*`, `4.3_*`, `4.4_*`, `5.1_*`, and `5.2_*`.

### Testing
- Ran `snakemake --lint` to validate rule syntax and references, which completed successfully.
- Ran a Snakemake dry-run with `snakemake -n` to verify the workflow parses and resource fields resolve correctly, which completed successfully.
- No full data-processing workflow executions were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2010a91f48832ca1b3f68d49adbc8a)