### PR TITLE
Extract gene column before filtering semicolons to avoid dropping genes in outlier lists

### DIFF
--- a/workflow/rules/4.1_positive_selection_selscan.smk
+++ b/workflow/rules/4.1_positive_selection_selscan.smk
@@ -178,7 +178,7 @@ rule get_selscan_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.selscan_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.selscan_genes} ) 2> {log} || true
+        ( sed '1d' {input.selscan_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.selscan_genes} ) 2> {log} || true
         sed -i '1iGene' {output.selscan_genes} 2>> {log}
         """
 

--- a/workflow/rules/4.2_positive_selection_selscan_xp.smk
+++ b/workflow/rules/4.2_positive_selection_selscan_xp.smk
@@ -201,7 +201,7 @@ rule get_selscan_xp_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.selscan_xp_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.selscan_xp_genes} ) 2> {log} || true
+        ( sed '1d' {input.selscan_xp_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.selscan_xp_genes} ) 2> {log} || true
         sed -i '1iGene' {output.selscan_xp_genes} 2>> {log}
         """
 

--- a/workflow/rules/4.3_positive_selection_scikit-allel.smk
+++ b/workflow/rules/4.3_positive_selection_scikit-allel.smk
@@ -175,7 +175,7 @@ rule get_tajima_d_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.tajima_d_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.tajima_d_genes} ) 2> {log} || true
+        ( sed '1d' {input.tajima_d_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.tajima_d_genes} ) 2> {log} || true
         sed -i '1iGene' {output.tajima_d_genes} 2>> {log}
         """
 

--- a/workflow/rules/4.4_positive_selection_scikit-allel_xp.smk
+++ b/workflow/rules/4.4_positive_selection_scikit-allel_xp.smk
@@ -174,7 +174,7 @@ rule get_delta_tajima_d_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.delta_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.delta_genes} ) 2> {log} || true
+        ( sed '1d' {input.delta_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.delta_genes} ) 2> {log} || true
         sed -i '1iGene' {output.delta_genes} 2>> {log}
         """
 

--- a/workflow/rules/5.1_balancing_selection_betascan.smk
+++ b/workflow/rules/5.1_balancing_selection_betascan.smk
@@ -143,7 +143,7 @@ rule get_betascan_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.betascan_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.betascan_genes} ) 2> {log} || true
+        ( sed '1d' {input.betascan_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.betascan_genes} ) 2> {log} || true
         sed -i '1iGene' {output.betascan_genes} 2>> {log}
         """
 

--- a/workflow/rules/5.2_balancing_selection_scikit-allel.smk
+++ b/workflow/rules/5.2_balancing_selection_scikit-allel.smk
@@ -173,7 +173,7 @@ rule get_tajima_d_balancing_outlier_genes:
         "../envs/selscape-env.yaml"
     shell:
         """
-        ( sed '1d' {input.tajima_d_outliers} | grep -v ";" | awk '{{print $7}}' | sort | uniq > {output.tajima_d_genes} ) 2> {log} || true
+        ( sed '1d' {input.tajima_d_outliers} | awk '{{print $7}}' | grep -v ";" | sort | uniq > {output.tajima_d_genes} ) 2> {log} || true
         sed -i '1iGene' {output.tajima_d_genes} 2>> {log}
         """
 


### PR DESCRIPTION
### Motivation
- The outlier gene extraction pipelines were filtering entire lines containing semicolons before extracting the gene column, which could inadvertently drop valid gene names when other columns contained `;` characters. 
- The change reorders commands so the gene column is extracted first and then semicolon-containing entries are filtered, preserving valid gene names.

### Description
- Reordered the shell pipelines in multiple Snakemake rules to run `awk '{print $7}'` before `grep -v ";"`, e.g. changing `sed '1d' | grep -v ";" | awk '{print $7}' | sort | uniq` to `sed '1d' | awk '{print $7}' | grep -v ";" | sort | uniq` and kept the header insertion with `sed -i '1iGene'`.
- Applied this fix across rules: `get_selscan_outlier_genes`, `get_selscan_xp_outlier_genes`, `get_tajima_d_outlier_genes`, `get_delta_tajima_d_outlier_genes`, `get_betascan_outlier_genes`, and `get_tajima_d_balancing_outlier_genes` (updates in `4.1`, `4.2`, `4.3`, `4.4`, `5.1`, and `5.2` rule files).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1b8ac0c4832ca4afc6168841b048)